### PR TITLE
chore: add s2 repo to proto update dispatch

### DIFF
--- a/.github/workflows/update_protos.yaml
+++ b/.github/workflows/update_protos.yaml
@@ -7,7 +7,7 @@ jobs:
   dispatch:
     strategy:
       matrix:
-        repo: ['s2-streamstore/s2-sdk-python', 's2-streamstore/s2-sdk-java', 's2-streamstore/s2-sdk-go', 's2-streamstore/s2-sdk-rust']
+        repo: ['s2-streamstore/s2-sdk-python', 's2-streamstore/s2-sdk-java', 's2-streamstore/s2-sdk-go', 's2-streamstore/s2-sdk-rust', 's2-streamstore/s2']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Dispatch s2-proto-update events to s2-streamstore/s2 when proto files change, enabling automatic submodule update PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)