### PR TITLE
feat(openapi): document basin timestamps

### DIFF
--- a/s2/v1/openapi.json
+++ b/s2/v1/openapi.json
@@ -2247,9 +2247,22 @@
         "type": "object",
         "required": [
           "name",
-          "state"
+          "created_at"
         ],
         "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation time in RFC 3339 format."
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "Deletion time in RFC 3339 format, if the basin is being deleted."
+          },
           "name": {
             "$ref": "#/components/schemas/BasinNameStr",
             "description": "Basin name."
@@ -2264,10 +2277,6 @@
                 "description": "Basin scope."
               }
             ]
-          },
-          "state": {
-            "$ref": "#/components/schemas/BasinState",
-            "description": "Basin state."
           }
         }
       },


### PR DESCRIPTION
Add basin lifecycle timestamps to the published OpenAPI schema and stop documenting the deprecated `state` field on `BasinInfo`.

- add `created_at` to `BasinInfo`
- add `deleted_at` to `BasinInfo`
- remove `state` from the published `BasinInfo` schema