### PR TITLE
Update basin endpoints from b.aws.s2.dev to b.s2.dev

### DIFF
--- a/s2/v1/openapi.json
+++ b/s2/v1/openapi.json
@@ -1002,7 +1002,7 @@
     "/streams": {
       "servers": [
         {
-          "url": "https://{basin}.b.aws.s2.dev/v1",
+          "url": "https://{basin}.b.s2.dev/v1",
           "description": "Endpoint for the basin",
           "variables": {
             "basin": {
@@ -1199,7 +1199,7 @@
     "/streams/{stream}": {
       "servers": [
         {
-          "url": "https://{basin}.b.aws.s2.dev/v1",
+          "url": "https://{basin}.b.s2.dev/v1",
           "description": "Endpoint for the basin",
           "variables": {
             "basin": {
@@ -1552,7 +1552,7 @@
     "/streams/{stream}/records": {
       "servers": [
         {
-          "url": "https://{basin}.b.aws.s2.dev/v1",
+          "url": "https://{basin}.b.s2.dev/v1",
           "description": "Endpoint for the basin",
           "variables": {
             "basin": {
@@ -1858,7 +1858,7 @@
     "/streams/{stream}/records/tail": {
       "servers": [
         {
-          "url": "https://{basin}.b.aws.s2.dev/v1",
+          "url": "https://{basin}.b.s2.dev/v1",
           "description": "Endpoint for the basin",
           "variables": {
             "basin": {


### PR DESCRIPTION
## Summary
- Update 4 basin server URLs in OpenAPI spec from `{basin}.b.aws.s2.dev` to `{basin}.b.s2.dev`

Once merged, the `sync_specs` workflow in the docs repo will propagate this to `specs-denorm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)