### PR TITLE
chore: upgrade and SHA-pin GitHub Actions dependencies

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -17,14 +17,14 @@ jobs:
           - "s2-streamstore/s2-sdk-python"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: ${{ matrix.repo }}


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions to latest versions
- SHA-pin all action references for supply chain security
- Verify all SHAs against upstream repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)