### PR TITLE
chore: regen openapi for new basin scopes

### DIFF
--- a/s2/v1/openapi.json
+++ b/s2/v1/openapi.json
@@ -2369,7 +2369,9 @@
       "BasinScope": {
         "type": "string",
         "enum": [
-          "aws:us-east-1"
+          "aws:us-east-1",
+          "aws:us-west-2",
+          "aws:eu-north-1"
         ]
       },
       "BasinState": {
@@ -2407,7 +2409,7 @@
               },
               {
                 "$ref": "#/components/schemas/BasinScope",
-                "description": "Basin scope."
+                "description": "Basin scope.\nIf omitted, defaults to `aws:us-east-1`."
               }
             ]
           }
@@ -2434,7 +2436,7 @@
               },
               {
                 "$ref": "#/components/schemas/BasinScope",
-                "description": "Basin scope.\nThis cannot be reconfigured."
+                "description": "Basin scope.\nIf omitted, defaults to `aws:us-east-1`.\nThis cannot be reconfigured."
               }
             ]
           }


### PR DESCRIPTION
## Summary
Regenerates `s2/v1/openapi.json` from s2 main following s2-streamstore/s2#430:

- Adds `aws:us-west-2` and `aws:eu-north-1` to the `BasinScope` enum.
- Surfaces the "defaults to `aws:us-east-1`" doc on `CreateBasinRequest.scope` and `CreateOrReconfigureBasinRequest.scope` (added in #430 specifically so the regen would carry it through).

## Test plan
- [x] Regenerated via \`cargo run --bin openapi -p s2-lite --features utoipa\` from s2 main (commit 8bab13f).
- [x] JSON parses.